### PR TITLE
Return current section if no tag is found

### DIFF
--- a/doc/helplink.txt
+++ b/doc/helplink.txt
@@ -21,7 +21,8 @@ COMMANDS                                                   *helplink-commands*
 
         Try to find the tag closest to the cursor (backwards search only) and
         format it. If multiple tags are found on the same line, it asks the
-        user which one to pick.
+        user which one to pick. If no tag is found them link to the current
+        section name.
 
         This will echo the formatted URL and copy them to the registers in
         |g:helplink_copy_to_registers|.

--- a/plugin/helplink.vim
+++ b/plugin/helplink.vim
@@ -66,7 +66,7 @@ fun! s:get_tag() abort
 
 	" Search backwards for the first tag
 	normal! $
-	if !search('\*\zs[^*]\+\*$', 'bcW')
+	if !search('\*\zs[^*]\+\*$', 'bcW') && !search('\*\zs[^*]\+\.[^*]\+\*', 'bcW')
 		call setpos('.', l:save_cursor)
 		echohl ErrorMsg | echom 'No tag found before the cursor.' | echohl None
 		return


### PR DESCRIPTION
I find this plugin very useful, thanks for sharing it!

Sometimes I find it useful to link to the user manual as well, but Helplink fails because no tags can be found.