### PR TITLE
Fixed some escape character problems.

### DIFF
--- a/plugin/helplink.vim
+++ b/plugin/helplink.vim
@@ -99,10 +99,10 @@ fun! s:quote_url(str) abort
 	let l:new = ''
 	for l:i in range(1, strlen(a:str))
 		let l:c = a:str[l:i - 1]
-		if l:c =~ '\w'
+		if l:c =~ '\w\|-'
 			let l:new .= l:c
 		else
-			let l:new .= printf('%%%02x', char2nr(l:c))
+			let l:new .= toupper(printf('%%%02x', char2nr(l:c)))
 		endif
 	endfor
 	return l:new


### PR DESCRIPTION
During testing capital letters needed to be used in escaped hex
characters to get the appropriate behavior. (Chrome version 56.0.2924.87)
When there was a `-`, it would convert it to `%2d`. However in testing
it needed to be left as a `-`.
Reference example: `:help map-<buffer>`