### PR TITLE
Fixed problem with encoding of "\".

### DIFF
--- a/plugin/helplink.vim
+++ b/plugin/helplink.vim
@@ -110,7 +110,7 @@ fun! s:quote_url(str) abort
 	let l:new = ''
 	for l:i in range(1, strlen(a:str))
 		let l:c = a:str[l:i - 1]
-		if l:c =~ '[a-zA-Z0-9\-\._]'
+		if l:c =~ '[a-zA-Z0-9\-._]'
 			let l:new .= l:c
 		else
 			let l:new .= toupper(printf('%%%02x', char2nr(l:c)))


### PR DESCRIPTION
When you [added `.` and and `_` to the non-encode list](https://github.com/Carpetsmoker/helplink.vim/commit/d7e555e88119cf62c10a68d6ca5d30860cd41ee9), you accidentally also added `\`. (The dot doesn't need to be escaped in a character class) `\` has been removed from the list.