### PR TITLE
Global Helplink command

### DIFF
--- a/autoload/helplink.vim
+++ b/autoload/helplink.vim
@@ -27,13 +27,40 @@ if !exists('g:helplink_always_ask')
 endif
 
 fun! helplink#link(...) abort
-	let l:format = (a:0 && !empty(a:1)) ? a:1 : g:helplink_default_format
+	let l:subject = ''
+	let l:format = g:helplink_default_format
+
+	if a:0 && !empty(a:1)
+		let l:args = split(a:1)
+		if has_key(g:helplink_formats, l:args[0])
+			let l:format = l:args[0]
+			if len(l:args) > 1
+				let l:subject = l:args[1]
+			endif
+		else
+			let l:subject = l:args[0]
+			if len(l:args) > 1 && has_key(g:helplink_formats, l:args[1])
+				let l:format = l:args[1]
+			endif
+		endif
+	endif
+
+	if &filetype !=# 'help' && l:subject ==# ''
+		echoerr 'Help subject required'
+		return
+	endif
+
 	if !has_key(g:helplink_formats, l:format)
 		echoerr "Unknown format: `" . l:format . "'"
 		return
 	endif
 
+	if len(l:subject)
+		silent execute 'tab help' l:subject
+	endif
+
 	let l:r = s:make_url()
+	if len(l:subject) | tabclose | endif
 	if empty(l:r) | return | endif
 
 	let [l:tagname, l:tagname_q, l:url] = l:r

--- a/autoload/helplink.vim
+++ b/autoload/helplink.vim
@@ -10,6 +10,7 @@ if !exists('g:helplink_formats')
 	\	'bbcode':      "'[url=' . l:url . '][code]:help ' . l:tagname . '[/code][/url]'",
 	\	'bbcode_h':    "'[url=' . l:url . '][code]:h ' . l:tagname . '[/code][/url]'",
 	\	'bbcode_nt':   "'[url=' . l:url . '][code]' . l:tagname . '[/code][/url]'",
+	\	'plain':       "l:url"
 	\}
 endif
 if !exists('g:helplink_copy_to_registers')

--- a/autoload/helplink.vim
+++ b/autoload/helplink.vim
@@ -2,7 +2,7 @@
 if !exists('g:helplink_formats')
 	let g:helplink_formats = {
 	\	'markdown':    "'[`:help ' . l:tagname . '`](' . l:url . ')'",
-	\	'markdown_h':  "'[`':h ' . l:tagname . '`](' . l:url . ')'",
+	\	'markdown_h':  "'[`:h ' . l:tagname . '`](' . l:url . ')'",
 	\	'markdown_nt': "'[`' . l:tagname . '`](' . l:url . ')'",
 	\	'html':        "'<a href=\"' . l:url . '\"><code>:help ' . l:tagname . '</code></a>'",
 	\	'html_h':      "'<a href=\"' . l:url . '\"><code>:h ' . l:tagname . '</code></a>'",

--- a/autoload/helplink.vim
+++ b/autoload/helplink.vim
@@ -1,16 +1,17 @@
-let g:helplink_formats = {
-\	'markdown':    "'[`:help ' . l:tagname . '`](' . l:url . ')'",
-\	'markdown_h':  "'[`':h ' . l:tagname . '`](' . l:url . ')'",
-\	'markdown_nt': "'[`' . l:tagname . '`](' . l:url . ')'",
-\	'html':        "'<a href=\"' . l:url . '\"><code>:help ' . l:tagname . '</code></a>'",
-\	'html_h':      "'<a href=\"' . l:url . '\"><code>:h ' . l:tagname . '</code></a>'",
-\	'html_nt':     "'<a href=\"' . l:url . '\"><code>' . l:tagname . '</code></a>'",
-\	'bbcode':      "'[url=' . l:url . '][code]:help ' . l:tagname . '[/code][/url]'",
-\	'bbcode_h':    "'[url=' . l:url . '][code]:h ' . l:tagname . '[/code][/url]'",
-\	'bbcode_nt':   "'[url=' . l:url . '][code]' . l:tagname . '[/code][/url]'",
-\}
-
 " Options
+if !exists('g:helplink_formats')
+	let g:helplink_formats = {
+	\	'markdown':    "'[`:help ' . l:tagname . '`](' . l:url . ')'",
+	\	'markdown_h':  "'[`':h ' . l:tagname . '`](' . l:url . ')'",
+	\	'markdown_nt': "'[`' . l:tagname . '`](' . l:url . ')'",
+	\	'html':        "'<a href=\"' . l:url . '\"><code>:help ' . l:tagname . '</code></a>'",
+	\	'html_h':      "'<a href=\"' . l:url . '\"><code>:h ' . l:tagname . '</code></a>'",
+	\	'html_nt':     "'<a href=\"' . l:url . '\"><code>' . l:tagname . '</code></a>'",
+	\	'bbcode':      "'[url=' . l:url . '][code]:help ' . l:tagname . '[/code][/url]'",
+	\	'bbcode_h':    "'[url=' . l:url . '][code]:h ' . l:tagname . '[/code][/url]'",
+	\	'bbcode_nt':   "'[url=' . l:url . '][code]' . l:tagname . '[/code][/url]'",
+	\}
+endif
 if !exists('g:helplink_copy_to_registers')
 	let g:helplink_copy_to_registers = ['+', '*']
 endif

--- a/doc/helplink.txt
+++ b/doc/helplink.txt
@@ -54,13 +54,15 @@ OPTIONS                                                     *helplink-options*
         {
         \  'markdown': "'[`:help ' . l:tagname . '`](' . l:url . ')'",
         \  'html':     "'<a href=\"' . l:url . '\">:help ' . l:tagname . '</a>'",
-        \  'bbcode':   "'[url=' . l:url . '][code]:help ' . l:tagname . '[/code][/url]'"
+        \  'bbcode':   "'[url=' . l:url . '][code]:help ' . l:tagname . '[/code][/url]'",
+        \  'plain':    "l:url"
         \}
 <
         This string is |eval|-ed, variables you can use are {l:tagname} and
-        {l:url}. For all three formats there are three variants denoted by a
-        suffix: `_h`, which uses `:h` instead of `:help`, and `_nt`, which
-        doesn't add a tag at all (e.g. `markdown_h`, `html_nt`, etc.)
+        {l:url}. For all three markup formats ("markdown", "html" and "bbcode")
+        there are three variants denoted by a suffix: `_h`, which uses `:h`
+        instead of `:help`, and `_nt`, which doesn't add a tag at all (e.g.
+        `markdown_h`, `html_nt`, etc.)
 
 *g:helplink_default_format*                        (String, default: markdown)
 

--- a/doc/helplink.txt
+++ b/doc/helplink.txt
@@ -17,13 +17,20 @@ http://meta.vi.stackexchange.com/a/1250/51
 ==============================================================================
 COMMANDS                                                   *helplink-commands*
 
-:Helplink {format}                                                 *:Helplink*
+:Helplink [subject] [format]                                       *:Helplink*
+>
+        :Helplink search() plain
+        :Helplink markdown_h 'shiftwidth'
+        :Helplink i^x^o
+<
+        Search for help {subject}. {subject} is required except inside help
+        buffers.
 
-        Try to find the tag closest to the cursor (backwards search only) and
-        format it. If multiple tags are found on the same line, it asks the
-        user which one to pick unless the cursor is currently on one of the
-        tags, in which case we assume the user wants to copy that tag and
-        don't ask for confirmation.
+        When run inside a help buffer, try to find the tag closest to the
+        cursor (backwards search only) and format it. If multiple tags are
+        found on the same line, it asks the user which one to pick unless the
+        cursor is currently on one of the tags, in which case we assume the
+        user wants to copy that tag and don't ask for confirmation.
         If no tag is found then it will link to the current filename (e.g.
         {syntax.txt}).
 

--- a/plugin/helplink.vim
+++ b/plugin/helplink.vim
@@ -13,11 +13,7 @@ let g:loaded_helplink = 1
 let s:save_cpo = &cpo
 set cpo&vim
 
-augroup helplink.vim
-	autocmd!
-	autocmd Filetype help 
-		\ command! -buffer -nargs=* Helplink call s:echo(helplink#link(<q-args>))
-augroup end
+command! -nargs=* -complete=help Helplink call s:echo(helplink#link(<q-args>))
 
 " Echo only if string is non-empty
 fun! s:echo(str)


### PR DESCRIPTION
Great plugin! I've been using it with some variations to write a vimways.org article - I've found it much quicker this way (without needing to first open help). This PR also includes a new default format "plain" which adds some flexibility.

The Helplink command now uses `-complete=help` to include tab-completion for help topics and can be used without needing to first open the help.

It works by opening the help in a new tab (to avoid modifying window layout), running as usual, then closing the tab - hopefully invisibly to the user.