### PR TITLE
Update link to online Vim documentation

### DIFF
--- a/autoload/helplink.vim
+++ b/autoload/helplink.vim
@@ -17,7 +17,7 @@ if !exists('g:helplink_copy_to_registers')
 	let g:helplink_copy_to_registers = ['+', '*']
 endif
 if !exists('g:helplink_url')
-	let g:helplink_url = 'http://vimhelp.appspot.com/%%FILE%%.html#%%TAGNAME_QUOTED%%'
+	let g:helplink_url = 'https://vimhelp.org/%%FILE%%.html#%%TAGNAME_QUOTED%%'
 endif
 if !exists('g:helplink_default_format')
 	let g:helplink_default_format = 'markdown'

--- a/doc/helplink.txt
+++ b/doc/helplink.txt
@@ -41,7 +41,7 @@ OPTIONS                                                     *helplink-options*
         Automatically copy the link to the specified registers.
 
 *g:helplink_url*                                 (URL, default:
-                 http://vimhelp.appspot.com/%%FILE%%.html#%%TAGNAME_QUOTED%%)
+                 https://vimhelp.org/%%FILE%%.html#%%TAGNAME_QUOTED%%)
 
         Available placeholders:
             - %%FILE%%            File name (e.g. |options.txt|)


### PR DESCRIPTION
According to these commits:
https://github.com/c4rlo/vimhelp/commit/565fe830fa62e2760cfb28975617e469631fb32f
https://github.com/c4rlo/vimhelp/commit/115ce1c1b802ed7a825e032f3a38831730959df2

The current URL is https://vimhelp.org

By the way, great plug-in!