### PR TITLE
Completion of available formats

### DIFF
--- a/autoload/helplink.vim
+++ b/autoload/helplink.vim
@@ -41,6 +41,10 @@ fun! helplink#link(...) abort
 	return l:out
 endfun
 
+function! helplink#complete(_argument_lead, _command_line, _cursor_position)
+	return join(sort(keys(g:helplink_formats)), "\n")
+endfunction
+
 "##########################################################
 " Helper functions
 

--- a/plugin/helplink.vim
+++ b/plugin/helplink.vim
@@ -15,8 +15,8 @@ set cpo&vim
 
 augroup helplink.vim
 	autocmd!
-	autocmd Filetype help 
-		\ command! -buffer -nargs=* Helplink call s:echo(helplink#link(<q-args>))
+	autocmd Filetype help
+		\ command! -buffer -nargs=* -complete=custom,helplink#complete Helplink call s:echo(helplink#link(<q-args>))
 augroup end
 
 " Echo only if string is non-empty


### PR DESCRIPTION
This PR adds basic completion of the argument to `Helplink`. I usually only use the default markdown option, but I wanted a plain URL just now and I realized I don't know how to get it. Needed to check the documentation, and completion would have avoided that round-trip (and spared me some typing with a `p<tab>` rather than the full `plain`).

This conflicts a bit with #7, since that PR wants to create a global command with help tag completion, which would make sense. It could check the input params for which argument it's currently completing, though it would certainly make the code (of that future command's completion) at least a bit more complicated.